### PR TITLE
update pep8 code tools to remove deprecation warnings

### DIFF
--- a/tools/run-pep8
+++ b/tools/run-pep8
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e
+set -e
 
 echo "= pycodestyle ="
 
@@ -10,15 +10,14 @@ command -v pycodestyle >/dev/null 2>&1 || {
   echo >&2 "$ pip install pycodestyle";
   exit 1;
 }
-alias FIND="find . -type f"
-for i in $(${FIND} -exec grep -l "env python3" {} \;); do
+for i in $(find . -type f -exec grep -l "env python3" {} \;); do
     if [[ $i != *pep8 && $i != *meson* && $i != *venv* ]]; then
         echo "checking $i"
         pycodestyle --ignore W191 --ignore E402 $i
     fi
 done
 
-for i in $(${FIND} -iname '*.py'); do
+for i in $(find . -type f -iname '*.py'); do
     if [[ $i != *venv* ]]; then
         echo "checking $i:"
         pycodestyle --ignore W191 --ignore E402 $i

--- a/tools/run-pep8
+++ b/tools/run-pep8
@@ -1,16 +1,26 @@
 #!/bin/bash
-set -e
+#set -e
 
-echo "= pep8 ="
+echo "= pycodestyle ="
 
-for i in `find . -type f -exec grep -l "env python3" {} \;`; do
-    if [[ $i != *pep8 && $i != *meson* ]]; then
+command -v pycodestyle >/dev/null 2>&1 || {
+  echo >&2 "I require pycodestyle but it's not installed.  Aborting.";
+  echo >&2 "$ virtualenv -p python3 venv";
+  echo >&2 "$ . venv/bin/activate";
+  echo >&2 "$ pip install pycodestyle";
+  exit 1;
+}
+alias FIND="find . -type f"
+for i in $(${FIND} -exec grep -l "env python3" {} \;); do
+    if [[ $i != *pep8 && $i != *meson* && $i != *venv* ]]; then
         echo "checking $i"
-        pep8 --ignore W191 --ignore E402 $i
+        pycodestyle --ignore W191 --ignore E402 $i
     fi
 done
 
-for i in `find . -iname '*.py'`; do
-    echo "checking $i"
-    pep8 --ignore W191 --ignore E402 $i 
+for i in $(${FIND} -iname '*.py'); do
+    if [[ $i != *venv* ]]; then
+        echo "checking $i:"
+        pycodestyle --ignore W191 --ignore E402 $i
+    fi
 done


### PR DESCRIPTION
replacing pep8 check with pycodestyle

when running tools/run-pep8, the response is
```
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.

$ pip install pycodestyle
$ pycodestyle ...
```

This PR addresses issue #155 