### PR TITLE
Check array lengths for preview buttons to prevent crashes #290

### DIFF
--- a/budgie-wpreviews/src/previews_daemon.vala
+++ b/budgie-wpreviews/src/previews_daemon.vala
@@ -309,7 +309,11 @@ namespace NewPreviews {
                     currtilindex = 0;
                 }
                 delete_file(nexttrigger);
-                currbuttons[currtilindex].grab_focus();
+                if (currtilindex <= currbuttons.length &&
+                    currtilindex >= 0) {
+                        currbuttons[currtilindex].grab_focus();
+                }
+
             }
             else if (previoustrigger.query_exists()) {
                 currtilindex -= 1;
@@ -317,7 +321,10 @@ namespace NewPreviews {
                     currtilindex =  currbuttons.length - 1;
                 }
                 delete_file(previoustrigger);
-                currbuttons[currtilindex].grab_focus();
+                if (currtilindex <= currbuttons.length &&
+                    currtilindex >= 0) {
+                        currbuttons[currtilindex].grab_focus();
+                }
             }
         }
 


### PR DESCRIPTION
@Jacob-Vlijm basically this issue - this is the proposed solution outlined in #290 

i.e. kill all windows on the desktop including plank

Then repeatedly alt+tab / let go / alt+tab again - rinse and repeat quickly.

Note - this doesn't resolve where pressing alt+tab and let go very quickly the preview window with nothing in it seems to stick open.