### PR TITLE
Fix keyboard-autoswitch crash when budgie-panel is started before a screensaver

### DIFF
--- a/budgie-keyboard-autoswitch/budgie-keyboard-autoswitch.py
+++ b/budgie-keyboard-autoswitch/budgie-keyboard-autoswitch.py
@@ -144,7 +144,7 @@ class KeyboardAutoSwitchApplet(Budgie.Applet):
 
         # Use dbus connection to check for the screensaver activity
         self.bus = dbus.SessionBus()
-        self.session = self.bus.get_object("org.gnome.ScreenSaver", "/")
+        self.screensaver = None
 
         # thread
         GObject.threads_init()
@@ -171,8 +171,14 @@ class KeyboardAutoSwitchApplet(Budgie.Applet):
             return " ".join(lang)
 
     def lockscreen_check(self):
-        val = self.session.get_dbus_method('GetActive')
-        return val()
+        try:
+            if self.screensaver is None:
+                self.screensaver = self.bus.get_object("org.gnome.ScreenSaver", "/")
+            val = self.screensaver.get_dbus_method('GetActive')
+            return val()
+        except dbus.exceptions.DBusException:
+            self.screensaver = None
+            return False
 
     def change_ondeflang_select(self, widget):
         """


### PR DESCRIPTION
In Ubuntu Budgie 20.04 (in my setup, at least) budgie-keyboard-autoswitch applet crashes on startup with `dbus.exceptions.DBusException`, because gnome-screensaver is only started after budgie-panel. This in turn leads to other applets on the panel forming a mess because their positions are improperly calculated after one applet has crashed.