### PR TITLE
Add layoutspopup-autostart to configurable xdg dir

### DIFF
--- a/budgie-window-shuffler/data/meson.build
+++ b/budgie-window-shuffler/data/meson.build
@@ -29,7 +29,7 @@ shufflerlayoutstargetauto = custom_target('layoutsautostart',
   input : 'layoutspopup-autostart.desktop.in',
   command : [substprog, '@INPUT@', LIB_INSTALL_DIR, '@OUTPUT@', podir],
   install : true,
-  install_dir : join_paths(sysconfdir, 'xdg', 'autostart')
+  install_dir : xdg_appdir
 )
 
 shufflertargetw = custom_target('shufflercontrols',


### PR DESCRIPTION
Not sure if this was intentional. After setting the build option `-Dxdg-appdir=/usr/share/xdg/autostart` this file `layoutspopup-autostart.desktop` was still on `/etc/xdg/autostart`.