### PR TITLE
Add Custom Clock Applet

### DIFF
--- a/budgie-customclock/CustomClockApplet.plugin.in
+++ b/budgie-customclock/CustomClockApplet.plugin.in
@@ -1,0 +1,8 @@
+[Plugin]
+Module=customclockapplet.so
+Name=Custom Clock
+_Description=a clock that can be customized
+Authors=Budgie Desktop Developers
+Copyright=Copyright © 2014-2021 Budgie Desktop Developers
+Website=https://budgie-desktop.org
+Icon=clock-applet-symbolic

--- a/budgie-customclock/CustomClockApplet.vala
+++ b/budgie-customclock/CustomClockApplet.vala
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2014-2021 Budgie Desktop Developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class CustomClockPlugin : Budgie.Plugin, Peas.ExtensionBase {
+	public Budgie.Applet get_panel_widget(string uuid) {
+		return new CustomClockApplet(uuid);
+	}
+}
+
+public const string CALENDAR_MIME = "text/calendar";
+
+public class CustomClockApplet : Budgie.Applet {
+	protected Gtk.EventBox widget;
+	protected Gtk.Label clock;
+
+	private DateTime time;
+
+	protected Settings settings;
+
+	Budgie.Popover? popover = null;
+	AppInfo? calprov = null;
+	Gtk.Button cal_button;
+
+	Gtk.Orientation orient = Gtk.Orientation.HORIZONTAL;
+
+	private unowned Budgie.PopoverManager? manager = null;
+
+	private TimeZone clock_timezone;
+	private string clock_format;
+
+	public string uuid { public set; public get; }
+
+	Gtk.Button new_plain_button(string label_str) {
+		Gtk.Button ret = new Gtk.Button.with_label(label_str);
+		ret.get_child().halign = Gtk.Align.START;
+		ret.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
+
+		return ret;
+	}
+
+	public CustomClockApplet(string uuid) {
+		Object(uuid: uuid);
+
+		settings_schema = "org.ubuntubudgie.budgie-customclock";
+		settings_prefix = "/org/ubuntubudgie/budgie-customclock/instance/clock";
+
+
+		settings = this.get_applet_settings(uuid);
+		
+		time = new DateTime.now_local();
+
+
+		widget = new Gtk.EventBox();
+		clock = new Gtk.Label("");
+		widget.add(clock);
+
+		clock.valign = Gtk.Align.CENTER;
+
+		get_style_context().add_class("budgie-clock-applet");
+
+		// Create a submenu system
+		popover = new Budgie.Popover(widget);
+
+		var stack = new Gtk.Stack();
+		stack.get_style_context().add_class("clock-applet-stack");
+
+		popover.add(stack);
+		stack.set_homogeneous(true);
+		stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
+
+		var menu = new Gtk.Box(Gtk.Orientation.VERTICAL, 1);
+		menu.border_width = 6;
+
+		var time_button = this.new_plain_button(_("System time and date settings"));
+		cal_button = this.new_plain_button(_("Calendar"));
+		time_button.clicked.connect(on_date_activate);
+		cal_button.clicked.connect(on_cal_activate);
+
+		// menu page 1
+		menu.pack_start(time_button, false, false, 0);
+		menu.pack_start(cal_button, false, false, 0);
+
+		stack.add_named(menu, "root");
+
+		// Always open to the root page
+		popover.closed.connect(() => {
+			stack.set_visible_child_name("root");
+		});
+
+		widget.button_press_event.connect((e) => {
+			if (e.button != 1) {
+				return Gdk.EVENT_PROPAGATE;
+			}
+			if (popover.get_visible()) {
+				popover.hide();
+			} else {
+				this.manager.show_popover(widget);
+			}
+			return Gdk.EVENT_STOP;
+		});
+
+		Timeout.add_seconds_full(Priority.LOW, 1, update_clock);
+
+		settings.changed.connect(on_settings_change);
+
+		calprov = AppInfo.get_default_for_type(CALENDAR_MIME, false);
+
+		var monitor = AppInfoMonitor.get();
+		monitor.changed.connect(update_cal);
+
+		cal_button.set_sensitive(calprov != null);
+		cal_button.clicked.connect(on_cal_activate);
+
+		update_cal();
+
+		
+		add(widget);
+
+		this.clock_timezone = new TimeZone(settings.get_string("timezone"));
+		this.clock_format = settings.get_string("format");
+		update_clock();
+		popover.get_child().show_all();
+
+		show_all();
+	}
+
+	void update_cal() {
+		calprov = AppInfo.get_default_for_type(CALENDAR_MIME, false);
+		cal_button.set_sensitive(calprov != null);
+	}
+
+	void on_date_activate() {
+		this.popover.hide();
+		var app_info = new DesktopAppInfo("gnome-datetime-panel.desktop");
+
+		if (app_info == null) {
+			return;
+		}
+		try {
+			app_info.launch(null, null);
+		} catch (Error e) {
+			message("Unable to launch gnome-datetime-panel.desktop: %s", e.message);
+		}
+	}
+
+	void on_cal_activate() {
+		this.popover.hide();
+
+		if (calprov == null) {
+			return;
+		}
+		try {
+			calprov.launch(null, null);
+		} catch (Error e) {
+			message("Unable to launch %s: %s", calprov.get_name(), e.message);
+		}
+	}
+
+	public override void update_popovers(Budgie.PopoverManager? manager) {
+		this.manager = manager;
+		manager.register_popover(widget, popover);
+	}
+
+	protected void on_settings_change(string key) {
+		switch (key) {
+			case "timezone":
+				this.clock_timezone = new TimeZone(settings.get_string(key));
+				this.update_clock();
+				break;
+			case "format":
+				this.clock_format = settings.get_string(key);
+				this.update_clock();
+				break;
+		}
+	}
+
+
+	/**
+	 * This is called once every second, updating the time
+	 */
+	protected bool update_clock() {
+		time = new DateTime.now(this.clock_timezone);
+
+		// Prevent unnecessary redraws
+		var old = clock.get_label();
+		var ctime = time.format(this.clock_format);
+		if (old == ctime) {
+			return true;
+		}
+
+		clock.set_markup(ctime);
+		this.queue_draw();
+
+		return true;
+	}
+
+	public override bool supports_settings() {
+		return true;
+	}
+
+	public override Gtk.Widget? get_settings_ui() {
+		return new CustomClockSettings(this.get_applet_settings(uuid));
+	}
+}
+
+
+[GtkTemplate (ui="/org/ubuntubudgie/budgie-customclock/settings.ui")]
+public class CustomClockSettings : Gtk.Grid {
+
+	[GtkChild]
+	private Gtk.Entry? txtFormat;
+	
+	[GtkChild]
+	private Gtk.Entry? txtTimezone;
+
+	public CustomClockSettings(Settings? settings) {
+		settings.bind("format", this.txtFormat, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("timezone", this.txtTimezone, "text", SettingsBindFlags.DEFAULT);
+	}
+
+}
+
+
+[ModuleInit]
+public void peas_register_types(TypeModule module) {
+	// boilerplate - all modules need this
+	var objmodule = module as Peas.ObjectModule;
+	objmodule.register_extension_type(typeof(Budgie.Plugin), typeof(CustomClockPlugin));
+}

--- a/budgie-customclock/CustomClockApplet.vala
+++ b/budgie-customclock/CustomClockApplet.vala
@@ -27,8 +27,6 @@ public class CustomClockApplet : Budgie.Applet {
 	AppInfo? calprov = null;
 	Gtk.Button cal_button;
 
-	Gtk.Orientation orient = Gtk.Orientation.HORIZONTAL;
-
 	private unowned Budgie.PopoverManager? manager = null;
 
 	private TimeZone clock_timezone;

--- a/budgie-customclock/meson.build
+++ b/budgie-customclock/meson.build
@@ -2,6 +2,8 @@
 
 gnome = import('gnome')
 
+LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', 'budgie-customclock')
+
 custom_target('plugin-file-customclock',
     input : 'CustomClockApplet.plugin.in',
     output : 'CustomClockApplet.plugin',

--- a/budgie-customclock/meson.build
+++ b/budgie-customclock/meson.build
@@ -1,0 +1,57 @@
+# Custom Clock Applet build
+
+gnome = import('gnome')
+
+custom_target('plugin-file-customclock',
+    input : 'CustomClockApplet.plugin.in',
+    output : 'CustomClockApplet.plugin',
+    command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
+    install : true,
+    install_dir : LIB_INSTALL_DIR)
+
+gresource = join_paths(meson.current_source_dir(), 'plugin.gresource.xml')
+
+# Compile the assets into the binary
+applet_clock_resources = gnome.compile_resources(
+    'clock-applet-resources',
+    gresource,
+    source_dir: meson.current_source_dir(),
+    c_name: 'budgie_customclock',
+)
+
+applet_clock_sources = [
+    'CustomClockApplet.vala',
+    applet_clock_resources,
+]
+
+
+shared_library(
+    'customclockapplet',
+    applet_clock_sources,
+    dependencies: [
+        dependency('budgie-1.0'),
+        dependency('gtk+-3.0'),
+        dependency('gio-unix-2.0'),
+        dependency('libpeas-gtk-1.0'),
+        meson.get_compiler('c').find_library('m', required: false)
+    ],
+    vala_args: [
+        '--pkg', 'gtk+-3.0',
+        '--pkg', 'glib-2.0',
+        '--pkg', 'gio-unix-2.0',
+        '--pkg', 'libpeas-1.0',
+        # Make gresource work
+        '--target-glib=2.38',
+        '--gresources=' + gresource,
+        '--vapidir=' + VAPI_DIR,
+    ],
+    install: true,
+    install_dir: LIB_INSTALL_DIR,
+)
+
+install_data(
+    'org.ubuntubudgie.budgie-customclock.gschema.xml',
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas'),
+)
+
+meson.add_install_script('meson_post_install.py')

--- a/budgie-customclock/meson_post_install.py
+++ b/budgie-customclock/meson_post_install.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+schemadir = os.path.join(os.environ["MESON_INSTALL_PREFIX"],
+                         "share", "glib-2.0", "schemas")
+
+if not os.environ.get("DESTDIR"):
+    print("Compiling gsettings schemas...")
+    subprocess.call(["glib-compile-schemas", schemadir])

--- a/budgie-customclock/org.ubuntubudgie.budgie-customclock.gschema.xml
+++ b/budgie-customclock/org.ubuntubudgie.budgie-customclock.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="budgie">
+<schema id="org.ubuntubudgie.budgie-customclock">
+    <key type="s" name="format">
+      <default>"%H:%M:%S %d.%m.%Y"</default>
+      <summary>Format</summary>
+      <description>Format of the clock</description>
+    </key>
+    <key type="s" name="timezone">
+      <default>"UTC"</default>
+      <summary>Timezone</summary>
+      <description>Timezone of the clock, leave empty for system default.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/budgie-customclock/plugin.gresource.xml
+++ b/budgie-customclock/plugin.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+        <gresource prefix="/org/ubuntubudgie/budgie-customclock">
+                <file preprocess="xml-stripblanks">settings.ui</file>
+        </gresource>
+</gresources>

--- a/budgie-customclock/settings.ui
+++ b/budgie-customclock/settings.ui
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="CustomClockSettings" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">4</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Format</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="txtFormat">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="placeholder_text" translatable="yes">%H:%M:%S %d.%m.%Y</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Timzeone</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="txtTimezone">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="placeholder_text" translatable="yes">UTC</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </template>
+</interface>

--- a/budgie-customclock/settings.ui
+++ b/budgie-customclock/settings.ui
@@ -36,7 +36,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Timzeone</property>
+        <property name="label" translatable="yes">Timezone</property>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/meson.build
+++ b/meson.build
@@ -243,3 +243,8 @@ build_window_shuffler = get_option('build-window-shuffler')
 if build_all == true or build_window_shuffler == true
 	subdir('budgie-window-shuffler')
 endif
+
+build_customclock = get_option('build-customclock')
+if build_all == true or build_customclock == true
+	subdir('budgie-customclock')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,3 +30,4 @@ option('build-window-shuffler', type: 'boolean', value: false, description: 'Bui
 option('with-zeitgeist', type : 'boolean', value : 'true', description : 'Add Zeitgeist support')
 option('with-stateless', type: 'boolean', value: false, description: 'Enable stateless XDG paths')
 option('xdg-appdir', type: 'string', description: 'XDG autostart path')
+option('build-customclock', type: 'boolean', value: false, description: 'Build customclock applet')


### PR DESCRIPTION
Hi there :wave: 
I needed an clock applet that is more configurable than the standard budgie clock.
So I made one myself.

It is basically the normal budgie clock except it bypasses the system settings and the user is able to format the clock (strftime format) and/or choose a different timezone.

I feel like this could be useful for other people hence this pull request.
