### PR TITLE
Fix budgie-visualspace screenshot

### DIFF
--- a/budgie-visualspace/README.md
+++ b/budgie-visualspace/README.md
@@ -2,4 +2,4 @@
 
 Budgie VisualSpace shows the current workspace(s), as bullet(s). The applet includes a menu to navigate to either one of the windows or their corresponding workspace.
 
-![screenshot-1](https://github.com/UbuntuBudgie/budgie-extras/blob/newvisual/budgie-visualspace/visualspace.png)
+![screenshot-1](https://github.com/UbuntuBudgie/budgie-extras/blob/master/budgie-visualspace/visualspace.png)


### PR DESCRIPTION
The link to the budgie-visualspace screenshot is dead (presumably the branch in question was deleted/merged)
This points to the current screenshot in the master branch to fix it.