### PR TITLE
Grok MMC (SD-card) devices as well as USB

### DIFF
--- a/budgie-dropby/dropby_tools.py
+++ b/budgie-dropby/dropby_tools.py
@@ -48,8 +48,7 @@ def get_usb():
             pass
         else:
             devpath = v.get("DEVPATH")
-            if devpath is not None:
-                if all(["usb" in v.get("DEVPATH"), uuid]):
+            if devpath and uuid and any(["usb" in devpath, "mmc" in devpath]):
                     relevant.append(uuid)
     return relevant
 
@@ -108,18 +107,18 @@ def get_volumes(allvols):
         # filter out usb devices
         uuid = v.get_uuid()
         if uuid in usb_devs:
+            path = uuid_todev(uuid)
             devdata = {
                 "volume": v,
                 "name": v.get_name(),
                 "uuid": uuid,
-                "device": uuid_todev(uuid),
+                "device": path,
                 "can_mount": v.can_mount(),
                 "icon": v.get_icon(),
                 "flashdrive": v.can_eject(),
                 "ismounted": v.get_mount(),
             }
             # try to determine usage
-            path = uuid_todev(uuid)
             try:
                 match = mounted_devspaths.index(path)
             except ValueError:


### PR DESCRIPTION
Fixes #409 .

This is an inelegant solution, as all it does is look for devices with "mmc" in the device path as well as "usb".  However, it leaves the tech debt about the same level (and fixes an unnecessary double call to uuid_to_udev(), which runs /usr/sbin/findfs via subprocess).

Works to recognize an inserted SD-card on my system (same as in original issue).