### PR TITLE
Don't override Gnome nightlight

### DIFF
--- a/budgie-brightness-controller/src/helpers/DimHelper.vala
+++ b/budgie-brightness-controller/src/helpers/DimHelper.vala
@@ -46,6 +46,7 @@ public class DimHelper
             color_settings = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SettingsDaemon.Color",
                 "/org/gnome/SettingsDaemon/Color");
         } catch (IOError e) {
+            color_settings = null;
             warning (e.message);
         }
         subprocessHelper = new SubprocessHelper();
@@ -177,6 +178,9 @@ public class DimHelper
 
     public bool NightlightOn() {
         // Returns true if Nightlight mode is currently on
+        if (color_settings == null) {
+            return false;
+        }
         return color_settings.nightlight_active;
     }
 

--- a/budgie-brightness-controller/src/helpers/DimHelper.vala
+++ b/budgie-brightness-controller/src/helpers/DimHelper.vala
@@ -16,6 +16,12 @@ using BrightnessController.Models;
 
 namespace BrightnessController.Helpers
 {
+    // Allow us to see if Gnome nightlight mode is on
+    [DBus (name = "org.gnome.SettingsDaemon.Color")]
+    interface ColorSettings : Object {
+        [DBus (name = "NightLightActive")]
+        public abstract bool nightlight_active { owned get; }
+    }
 /**
  * DimHelper is a helper to work with
  * xrandr
@@ -30,11 +36,18 @@ public class DimHelper
 
     private SubprocessHelper subprocessHelper;
     private ConfigHelper configHelper;
+    private ColorSettings? color_settings;
 
     // private int noOfConnectedDev = 0;
 
     public DimHelper()
     {
+        try {
+            color_settings = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SettingsDaemon.Color",
+                "/org/gnome/SettingsDaemon/Color");
+        } catch (IOError e) {
+            warning (e.message);
+        }
         subprocessHelper = new SubprocessHelper();
         configHelper  = new ConfigHelper("budgie-advanced-brightness-controller", "dim");
         Load();
@@ -161,5 +174,11 @@ public class DimHelper
         });
         configHelper.Write(data);
     }
+
+    public bool NightlightOn() {
+        // Returns true if Nightlight mode is currently on
+        return color_settings.nightlight_active;
+    }
+
 }
 }

--- a/budgie-brightness-controller/src/widgets/Popover.vala
+++ b/budgie-brightness-controller/src/widgets/Popover.vala
@@ -127,11 +127,13 @@ public class Popover : Budgie.Popover
             dimHelper.SetBrightness(CurrentDim.Name, CurrentDim.Brightness, CurrentDim.Blue);
         });
 
-        Timeout.add_seconds(5, ()=>
-        {
-            dimHelper.SetBrightness(CurrentDim.Name, CurrentDim.Brightness, CurrentDim.Blue);
-            return(false);
-        });
+        // We don't want to load these color settings if Gnome's nightlight mode is on
+        if (!dimHelper.NightlightOn()) {
+            Idle.add(()=> {
+                dimHelper.SetBrightness(CurrentDim.Name, CurrentDim.Brightness, CurrentDim.Blue);
+                return(false);
+            });
+        }
 
         grid.attach(menuButton, 1, 0, 2, 1);
 
@@ -178,7 +180,7 @@ public class Popover : Budgie.Popover
 
         });
 
-        Timeout.add_seconds(5, ()=> {
+        Idle.add(()=> {
             //lightHelper.SetBrightness(CurrentLight.Name, CurrentLight.Brightness);
             lightHelper.SetBrightness((int)((double)CurrentLight.Brightness / (double)CurrentLight.MaxBrightness * 100.0));
             return(false);
@@ -252,7 +254,13 @@ public class Popover : Budgie.Popover
 
         UpdateLight.begin();
 
-        dimHelper.SetBrightness(CurrentDim.Name, CurrentDim.Brightness, CurrentDim.Blue);
+        /* SetBrightness will override Gnome's nightlight mode color settings. We don't
+         * want to do this just by opening the popover, so we skip it if nightlight is on.
+         * Sliders will still work as expected, however.
+         */
+        if (!dimHelper.NightlightOn()) {
+            dimHelper.SetBrightness(CurrentDim.Name, CurrentDim.Brightness, CurrentDim.Blue);
+        }
         PopulateDim(CurrentDim);
     }
     //[END On]


### PR DESCRIPTION
If Gnome nightlight is currently active, don't apply the color temperature changes every time the popover is simply opened or on initial load. This prevents a situation where the applet and the nightlight mode conflict and change the color back and forth.

Also included is a minor tweak to use Idle instead of a 5 second Timeout so the display settings are loaded more seamlessly on login.

Closes #441 