### PR TITLE
don't hardcode weathershow icon path

### DIFF
--- a/budgie-weathershow/meson.build
+++ b/budgie-weathershow/meson.build
@@ -30,7 +30,7 @@ install_data('schema/org.ubuntubudgie.plugins.weathershow.gschema.xml',
 
 install_data(
     'cities',
-    install_dir: join_paths(LIB_INSTALL_DIR)
+    install_dir: WEATHERSHOW_DATADIR
 )
 
 

--- a/budgie-weathershow/src/desktop_weather/desktop_weather.vala
+++ b/budgie-weathershow/src/desktop_weather/desktop_weather.vala
@@ -307,10 +307,7 @@ public class DesktopWeather : Gtk.Window {
 
     private void get_icondata () {
         // fetch the icon list
-        string icondir = "/".concat(
-            "usr/lib/budgie-desktop/plugins",
-            "/budgie-weathershow/weather_icons"
-        );
+        string icondir = GLib.Path.build_filename(Config.WEATHERSHOW_DIR, "weather_icons");
         iconnames = {};
         iconpixbufs_1 = {};
         iconpixbufs_2 = {};

--- a/budgie-weathershow/src/desktop_weather/desktop_weather.vala
+++ b/budgie-weathershow/src/desktop_weather/desktop_weather.vala
@@ -307,7 +307,7 @@ public class DesktopWeather : Gtk.Window {
 
     private void get_icondata () {
         // fetch the icon list
-        string icondir = GLib.Path.build_filename(Config.WEATHERSHOW_DIR, "weather_icons");
+        string icondir = GLib.Path.build_filename(Config.WEATHERSHOW_DATADIR, "weather_icons");
         iconnames = {};
         iconpixbufs_1 = {};
         iconpixbufs_2 = {};

--- a/budgie-weathershow/src/desktop_weather/meson.build
+++ b/budgie-weathershow/src/desktop_weather/meson.build
@@ -47,6 +47,7 @@ executable(
     install: true,
     vala_args: DesktopWeatherValaArgs,
     c_args: DesktopWeatherCArgs,
+    include_directories: config_inc_dir,
     install_dir: LIB_INSTALL_DIR,
 )
 

--- a/budgie-weathershow/src/weathershow/WeatherShow.vala
+++ b/budgie-weathershow/src/weathershow/WeatherShow.vala
@@ -165,9 +165,11 @@ namespace WeatherShowFunctions {
         } return -1;
     }
 
-    private string[] get_matches(string lookfor, string dir) {
+    private string[] get_matches(string lookfor) {
         // find matching cities
-        File datasrc = File.new_for_path(dir.concat("/cities"));
+        string citiesfile = GLib.Path.build_filename(Config.WEATHERSHOW_DATADIR, "cities");
+        File datasrc = File.new_for_path(citiesfile);
+
         string fixed = lookfor.down().to_ascii();
         try {
             var dis = new DataInputStream (datasrc.read ());
@@ -990,9 +992,7 @@ namespace WeatherShowApplet {
         private string set_initialcity() {
             // on opening settings, set the gui to the current value
             string initial_citycode = citycode;
-            string[] initline = WeatherShowFunctions.get_matches(
-                initial_citycode, moduledir
-            );
+            string[] initline = WeatherShowFunctions.get_matches(initial_citycode);
             // fix for change of cityfile (!)
             if (initline.length == 0) {
                 citycode = "2643743";
@@ -1084,9 +1084,7 @@ namespace WeatherShowApplet {
                 edit_citymenu == true &&
                 entry != null
                 ) {
-                string[] matches = WeatherShowFunctions.get_matches(
-                    currentry, moduledir
-                );
+                string[] matches = WeatherShowFunctions.get_matches(currentry);
                 int n_matches = matches.length;
                 if (n_matches > 0) {
                     foreach (string s in matches) {
@@ -1507,7 +1505,7 @@ namespace WeatherShowApplet {
 
         private void get_icondata () {
             // fetch the icon list
-            string icondir = moduledir.concat("/weather_icons");
+            string icondir = GLib.Path.build_filename(Config.WEATHERSHOW_DATADIR, "weather_icons");
             iconnames = {}; iconpixbufs = {}; iconpixbufs_large = {};
             try {
                 var dr = Dir.open(icondir);

--- a/budgie-weathershow/weather_icons/meson.build
+++ b/budgie-weathershow/weather_icons/meson.build
@@ -67,5 +67,5 @@ install_data(
     '804d-overcast-clouds.svg',
     '804n-overcast-clouds.svg',
     'error_icon.svg',
-    install_dir: join_paths(LIB_INSTALL_DIR, 'weather_icons')
+    install_dir: join_paths(WEATHERSHOW_DATADIR, 'weather_icons')
 )

--- a/meson.build
+++ b/meson.build
@@ -71,6 +71,9 @@ conf.set_quoted('PREVIEWS_DIR', join_paths(libdir, PREVIEWS))
 WSWITCHER = 'budgie-wswitcher'
 conf.set_quoted('WSWITCHER_DIR', join_paths(PLUGINS_INSTALL_DIR, WSWITCHER))
 
+WEATHERSHOW = 'budgie-weathershow'
+conf.set_quoted('WEATHERSHOW_DIR', join_paths(PLUGINS_INSTALL_DIR, WEATHERSHOW))
+
 with_stateless = get_option('with-stateless')
 if with_stateless == true
     warning('Only use stateless option with a supported OS like Solus')

--- a/meson.build
+++ b/meson.build
@@ -71,8 +71,8 @@ conf.set_quoted('PREVIEWS_DIR', join_paths(libdir, PREVIEWS))
 WSWITCHER = 'budgie-wswitcher'
 conf.set_quoted('WSWITCHER_DIR', join_paths(PLUGINS_INSTALL_DIR, WSWITCHER))
 
-WEATHERSHOW = 'budgie-weathershow'
-conf.set_quoted('WEATHERSHOW_DIR', join_paths(PLUGINS_INSTALL_DIR, WEATHERSHOW))
+WEATHERSHOW_DATADIR = join_paths(datadir, 'budgie-desktop', 'budgie-weathershow')
+conf.set_quoted('WEATHERSHOW_DATADIR', WEATHERSHOW_DATADIR)
 
 with_stateless = get_option('with-stateless')
 if with_stateless == true

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -9,4 +9,5 @@ namespace Config {
     public const string SHUFFLER_DIR;
     public const string PREVIEWS_DIR;
     public const string WSWITCHER_DIR;
+    public const string WEATHERSHOW_DIR;
 }

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -9,5 +9,5 @@ namespace Config {
     public const string SHUFFLER_DIR;
     public const string PREVIEWS_DIR;
     public const string WSWITCHER_DIR;
-    public const string WEATHERSHOW_DIR;
+    public const string WEATHERSHOW_DATADIR;
 }


### PR DESCRIPTION
This PR addresses the hardcoded path to the weathershow icons to make it friendly to other distros. It follows the same conventions used by the other applets for the sake of consistency, adding a WEATHERSHOW_DIR to config.vapi. 

I have built on both 24.04 / 24.10, as well as on a Fedora VM to test.

Closes #426