### PR TITLE
budgie-hotcorners: Fix formatting of defaults file JSON

### DIFF
--- a/budgie-hotcorners/misc/defaults.in
+++ b/budgie-hotcorners/misc/defaults.in
@@ -1,13 +1,13 @@
-{'command': '@bdesktopdir@/showdesktop/showdesktop', 'name': 'Show Desktop'}
-{'command': '@libdir@/budgie-previews/previews_triggers hotcorners_all', 'name': 'Exposé all windows', 'gsettingsboolean': 'org.ubuntubudgie.budgie-wpreviews enable-previews'}
-{'command': '@libdir@/budgie-previews/previews_triggers hotcorners_current', 'name': 'Exposé current application', 'gsettingsboolean': 'org.ubuntubudgie.budgie-wpreviews enable-previews'}
-{'command': 'budgie-desktop-settings', 'name':'Budgie Desktop Settings'}
-{'command': 'dbus-send --session --type="method_call" --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock', 'name': 'Lock screen'}
-{'command': '@libdir@/budgie-window-shuffler/togglegui', 'name': 'Toggle Shuffler GUI', 'gsettingsboolean': 'org.ubuntubudgie.windowshuffler runshufflergui'}
-{'command': '@libdir@/budgie-window-shuffler/grid_all', 'name': 'All windows in grid'}
-{'command': '@libdir@/budgie-window-shuffler/tile_active 0 0 2 2', 'name': 'Window to topleft'}
-{'command': '@libdir@/budgie-window-shuffler/tile_active 1 0 2 2', 'name': 'Window to topright'}
-{'command': '@libdir@/budgie-window-shuffler/tile_active 1 1 2 2', 'name': 'Window to bottomright'}
-{'command': '@libdir@/budgie-window-shuffler/tile_active 0 1 2 2', 'name': 'Window to bottomleft'}
-{'command': 'dbus-send --session --type="method_call" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleAppletView', 'name': 'Toggle Raven - AppletView'}
-{'command': 'dbus-send --session --type="method_call" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleNotificationsView', 'name': 'Toggle Raven - Notifications'}
+{"command": "@bdesktopdir@/showdesktop/showdesktop", "name": "Show Desktop"}
+{"command": "@libdir@/budgie-previews/previews_triggers hotcorners_all", "name": "Exposé all windows", "gsettingsboolean": "org.ubuntubudgie.budgie-wpreviews enable-previews"}
+{"command": "@libdir@/budgie-previews/previews_triggers hotcorners_current", "name": "Exposé current application", "gsettingsboolean": "org.ubuntubudgie.budgie-wpreviews enable-previews"}
+{"command": "budgie-desktop-settings", "name":"Budgie Desktop Settings"}
+{"command": "dbus-send --session --type=\"method_call\" --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock", "name": "Lock screen"}
+{"command": "@libdir@/budgie-window-shuffler/togglegui", "name": "Toggle Shuffler GUI", "gsettingsboolean": "org.ubuntubudgie.windowshuffler runshufflergui"}
+{"command": "@libdir@/budgie-window-shuffler/grid_all", "name": "All windows in grid"}
+{"command": "@libdir@/budgie-window-shuffler/tile_active 0 0 2 2", "name": "Window to topleft"}
+{"command": "@libdir@/budgie-window-shuffler/tile_active 1 0 2 2", "name": "Window to topright"}
+{"command": "@libdir@/budgie-window-shuffler/tile_active 1 1 2 2", "name": "Window to bottomright"}
+{"command": "@libdir@/budgie-window-shuffler/tile_active 0 1 2 2", "name": "Window to bottomleft"}
+{"command": "dbus-send --session --type=\"method_call\" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleAppletView", "name": "Toggle Raven - AppletView"}
+{"command": "dbus-send --session --type=\"method_call\" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleNotificationsView", "name": "Toggle Raven - Notifications"}


### PR DESCRIPTION
Without this formatting change `json-glib-validate` puts out the following error:

```<data>:1:1: Parse error: unexpected character `{', expected string constant```

Potentially due to the "Improve conformance of the JSON parser" change in json-glib 1.10? (https://gitlab.gnome.org/GNOME/json-glib/-/raw/1.10.0/NEWS?ref_type=tags)

Resolves https://github.com/UbuntuBudgie/budgie-extras/issues/486