### PR TITLE
Add AppStream metainfo files for all applets

### DIFF
--- a/budgie-app-launcher/data/meson.build
+++ b/budgie-app-launcher/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.applauncher.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml
+++ b/budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.applauncher</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie App Launcher</name>
+  <summary>App Launcher is a Budgie Desktop applet for productivity</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      App Launcher is a Budgie Desktop applet for productivity. This applet lists your favourite apps.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The app launcher popover</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-app-launcher/screenshots/screenshot1.gif</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-app-launcher/meson.build
+++ b/budgie-app-launcher/meson.build
@@ -8,3 +8,4 @@ conf.set('PROJECT_NAME', meson.project_name())
 message('Installing applet...')
 
 subdir('src')
+subdir('data')

--- a/budgie-brightness-controller/data/meson.build
+++ b/budgie-brightness-controller/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.brightnesscontroller.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml
+++ b/budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.brightnesscontroller</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Brightness Controller</name>
+  <summary>Brightness Controller is a Budgie Desktop applet for productivity</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Brightness Controller is a Budgie Desktop applet for productivity.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Brightness controller light theme</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-brightness-controller/screenshots/screenshot1.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Brightness controller dark theme</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-brightness-controller/screenshots/screenshot2.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-brightness-controller-1-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-brightness-controller/meson.build
+++ b/budgie-brightness-controller/meson.build
@@ -13,4 +13,5 @@ DEPENDENCY_BUDGIE = budgie_dep
 message('Installing applet...')
 
 subdir('src')
+subdir('data')
 subdir('icons')

--- a/budgie-clockworks/data/meson.build
+++ b/budgie-clockworks/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.clockworks.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml
+++ b/budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.clockworks</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie App Launcher</name>
+  <summary>A multi-clock applet to show the time across multiple timezones</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      A multi- clock applet to show the time across multiple timezones. Clocks can be created and deleted in a single click, and easily be (re-) named. Timezones can be looked up from the applet's popup menu.
+    </p>
+    <p>
+      The applet's colors are fully customizable from Budgie Settings.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-clockworks/applet.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-clockworks-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-clockworks/meson.build
+++ b/budgie-clockworks/meson.build
@@ -24,4 +24,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-clockworks.gschema.xml',
     install_dir: '/usr/share/glib-2.0/schemas'
 )
 
+subdir('data')
+
 meson.add_install_script('meson_post_install.py')

--- a/budgie-countdown/data/meson.build
+++ b/budgie-countdown/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.countdown.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml
+++ b/budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.countdown</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Countdown</name>
+  <summary>A count down applet with many different options</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      A count down applet with the following options: ring a bell, flash the (panel) icon, display a message window or run a (any) command. The applet also offers the option to overrule possible user settings on suspend, to keep the clock going while time is running.
+    </p>
+    <p>
+      The panel icon switches color, depending on remaining time; green, yellow (&lt; 5 minutes left) or red (&lt; 1 minute left).
+    </p>
+    <p>
+      The countdown label will be invisible until the clock starts running.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-countdown/applet.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-countdown-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-countdown/meson.build
+++ b/budgie-countdown/meson.build
@@ -30,4 +30,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-countdown.gschema.xml',
     install_dir: '/usr/share/glib-2.0/schemas'
 )
 
+subdir('data')
+
 meson.add_install_script('meson_post_install.py')

--- a/budgie-dropby/data/meson.build
+++ b/budgie-dropby/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.dropby.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml
+++ b/budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.dropby</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie DropBy</name>
+  <summary>The DropBy applet pops up on the occasion of connecting a usb device</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      The DropBy applet pops up on the occasion of connecting a usb device. The applet subsequently offers the option(s) to mount, unmount/eject, and, in case of a flash drive, to make a local copy of the drive's content. The info shows the free space on the volume.
+    </p>
+    <p>
+      The applet is context-sensitive, meaning: it only shows its icon in the panel if, and as long as, any usb drive is connected.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-dropby/dropby_copy.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-dropby/dropby_open.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-dropby-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-dropby/meson.build
+++ b/budgie-dropby/meson.build
@@ -25,4 +25,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-dropby.gschema.xml',
     install_dir: '/usr/share/glib-2.0/schemas'
 )
 
+subdir('data')
+
 meson.add_install_script('meson_post_install.py')

--- a/budgie-fuzzyclock/data/meson.build
+++ b/budgie-fuzzyclock/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.fuzzyclock.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml
+++ b/budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.fuzzyclock</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Fuzzy Clock</name>
+  <summary>Shows the time in a Fuzzy Way</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Shows the time in a Fuzzy Way. It supports 24-hour format, dates, and horizontal panels.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-fuzzyclock/menu.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-fuzzyclock/meson.build
+++ b/budgie-fuzzyclock/meson.build
@@ -5,3 +5,4 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
 message('Installing applet...')
 
 subdir('src')
+subdir('data')

--- a/budgie-hotcorners/misc/meson.build
+++ b/budgie-hotcorners/misc/meson.build
@@ -38,3 +38,7 @@ custom_target('desktop-file-hotcorners',
     command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
     install : true,
     install_dir : join_paths(datadir, 'applications'))
+
+install_data('org.ubuntubudgie.hotcorners.metainfo.xml',
+    install_dir: join_paths(datadir, 'metainfo')
+)

--- a/budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml
+++ b/budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.hotcorners</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie HotCorners</name>
+  <summary>Budgie Hotcorners offers the option to set corner actions for any of the corners or screen edges</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+        Budgie Hotcorners offers the option to set corner actions for any of the corners or screen edges, from presets or custom commands.
+    </p>
+    <p>
+      Budgie Hotcorners is (as of now) a mini-app and can be accessed from the main menu. Additionally, an applet is available for quick access, switch on/off or edit actions.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-hotcorners/applet.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">org.ubuntubudgie.budgie-extras.hotcorners</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-kangaroo/data/meson.build
+++ b/budgie-kangaroo/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.kangaroo.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml
+++ b/budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.kangaroo</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Kangaroo</name>
+  <summary>Kangaroo is an applet for quick &amp; easy browsing, across (possibly) many directory layers</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Kangaroo is an applet for quick &amp; easy browsing, across (possibly) many directory layers, without having to do a single mouse click.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-kangaroo/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-foldertrack-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-kangaroo/meson.build
+++ b/budgie-kangaroo/meson.build
@@ -20,3 +20,5 @@ install_data(
     'budgie-foldertrack-symbolic.svg',
     install_dir: PIXMAPS_DIR
 )
+
+subdir('data')

--- a/budgie-keyboard-autoswitch/data/meson.build
+++ b/budgie-keyboard-autoswitch/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.keyboardautoswitch.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml
+++ b/budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.keyboardautoswitch</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Keyboard Autoswitch</name>
+  <summary>Keyboard Auto Switch is an applet to use a different input keyboard layout per application</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Keyboard Auto Switch is an applet to use a different input keyboard layout per application. Simply set a default layout to be used in general. Subsequently, simply set a different layout, with the application's window in front, and an exception for that specific application is remembered.
+    </p>
+    <p>
+      Exceptions can be removed at any time, either from the applet's menu or by setting the application's layout, again, with its window in front.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/applet.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Settings window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/settings.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Languages window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/languages.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Exceptions window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/exceptions.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-keyboard-autoswitch-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-keyboard-autoswitch/meson.build
+++ b/budgie-keyboard-autoswitch/meson.build
@@ -12,3 +12,5 @@ install_data(
     'budgie-keyboard-autoswitch-symbolic.svg',
     install_dir: PIXMAPS_DIR
 )
+
+subdir('data')

--- a/budgie-quicknote/data/meson.build
+++ b/budgie-quicknote/data/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  'org.ubuntubudgie.quicknote.metainfo.xml',
+  install_dir: join_paths(get_option('datadir'), 'metainfo'),
+)

--- a/budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml
+++ b/budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.quicknote</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Quicknote</name>
+  <summary>An applet to provide the easiest possible way to make small notes</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Budgie Quicknote is is an applet to provide the easiest possible way to make small notes. Just click the icon and write down your notes. QuickNote autosaves the text while writing, and comes with a ten- level undo/redo function.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-quicknote/quicknote.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-quicknote-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-quicknote/meson.build
+++ b/budgie-quicknote/meson.build
@@ -54,4 +54,6 @@ install_data(
     install_dir: join_paths(datadir, 'glib-2.0', 'schemas'),
 )
 
+subdir('data')
+
 meson.add_install_script('meson_post_install.py')

--- a/budgie-recentlyused/data/meson.build
+++ b/budgie-recentlyused/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.recentlyused.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml
+++ b/budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.recentlyused</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Recently Used</name>
+  <summary>Show (Gtk applications') recently used items in a menu</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Show (Gtk applications') recently used items in a menu.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-recentlyused/menu.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-recentlyused/meson.build
+++ b/budgie-recentlyused/meson.build
@@ -10,5 +10,6 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
 message('Installing applet...')
 
 subdir('src')
+subdir('data')
 
 meson.add_install_script('meson_post_install.py')

--- a/budgie-rotation-lock/data/meson.build
+++ b/budgie-rotation-lock/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.rotationlock.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml
+++ b/budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.rotationlock</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie RotationLock</name>
+  <summary>A simple applet that lets you toggle the "Rotation Lock" feature for Budgie</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      RotationLock is a simple applet that lets you toggle the "Rotation Lock" feature for Budgie.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-rotationlock/rotationlock.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-rotation-button-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-rotation-lock/meson.build
+++ b/budgie-rotation-lock/meson.build
@@ -13,3 +13,5 @@ install_data(
     'budgie-rotation-lock-button-symbolic.svg',
     install_dir: PIXMAPS_DIR
 )
+
+subdir('data')

--- a/budgie-showtime/data/meson.build
+++ b/budgie-showtime/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.showtime.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml
+++ b/budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.showtime</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie ShowTime</name>
+  <summary>Budgie Showtime is a digital desktop clock, showing time, and optionally, date</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Textcolor of both can be set separately from the applet's menu.
+    </p>
+    <p>
+      Settings from Budgie Settings include text alignment, -color, -size, temporarily make the applet dragable for custom positioning, 12 hrs format, custom data formatting
+    </p>
+    <p>
+      Furthermore, gsettings overrides can be done for font (-family), left or right bottom positioning.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <icon type="stock">showtimenew-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-showtime/meson.build
+++ b/budgie-showtime/meson.build
@@ -9,6 +9,7 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
 message('Installing applet...')
 
 subdir('src')
+subdir('data')
 subdir('icons')
 
 meson.add_install_script('meson_post_install.py')

--- a/budgie-takeabreak/data/meson.build
+++ b/budgie-takeabreak/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.takeabreak.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml
+++ b/budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.takeabreak</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie TakeABreak</name>
+  <summary>A pomodoro-like applet, to make sure to take regular breaks from working</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Budgie TakeaBreak is a pomodoro- like applet, to make sure to take regular breaks from working. Options from Budgie Settings include turning the screen upside down, dim the screen, lock screen or show a countdown message on break time. The applet can be accessed quickly from the panel to temporarily switch it off.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/switch1.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/switch2.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/options.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">takeabreak-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-takeabreak/meson.build
+++ b/budgie-takeabreak/meson.build
@@ -28,4 +28,6 @@ install_data('schema/org.ubuntubudgie.plugins.takeabreak.gschema.xml',
     install_dir: '/usr/share/glib-2.0/schemas'
 )
 
+subdir('data')
+
 meson.add_install_script('meson_post_install.py')

--- a/budgie-visualspace/data/meson.build
+++ b/budgie-visualspace/data/meson.build
@@ -4,6 +4,10 @@ install_data(
     install_dir: PIXMAPS_DIR
 )
 
+install_data('org.ubuntubudgie.visualspace.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)
+
 substprog = find_program('subst.py')
 
 mytarget = custom_target('autoworkspace',

--- a/budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml
+++ b/budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.visualspace</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie VisualSpace</name>
+  <summary>Shows the current workspaces, as bullets</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Budgie VisualSpace shows the current workspace(s), as bullet(s). The applet includes a menu to navigate to either one of the windows or their corresponding workspace.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-visualspace/visualspace.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">visualspace-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-weathershow/data/meson.build
+++ b/budgie-weathershow/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.weathershow.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml
+++ b/budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.weathershow</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie WeatherShow II</name>
+  <summary>A completely rewritten version of the existing python WeatherShow applet</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      WeatherShowII is a completely rewritten version of the existing python WeatherShow applet. It merges the functionality of Budgie Weather applet (showing weather in the panel) and WeatherShow. Each of the modules: weather forecast, weather in the panel and weather on the desktop can be switched on and of.
+    </p>
+    <p>
+      The applet includes many technical improvements under the hood. Weather forecast now has its own thread, therefore the panel should not suffer in any way from possible possible delays or issues in fetching the forecast (e.g. in case of network- related problems). Furthermore, the applet adapts (in three steps) to the monitor's size, for better scaling on high resolutions.
+    </p>
+    <p>
+      WeatherShow uses an OWM key with permission of Open Weather Map. Permission was granted to UbuntuBudgie developers. Please don't copy!
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <icon type="stock">budgie-wticon-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-weathershow/meson.build
+++ b/budgie-weathershow/meson.build
@@ -25,5 +25,6 @@ message('Installing applet...')
 subdir('src')
 subdir('weather_icons')
 subdir('icons_for_pixmaps')
+subdir('data')
 
 meson.add_install_script('meson_post_install.py')

--- a/budgie-workspace-stopwatch/data/meson.build
+++ b/budgie-workspace-stopwatch/data/meson.build
@@ -1,0 +1,3 @@
+install_data('org.ubuntubudgie.workspacestopwatch.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml
+++ b/budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.workspacestopwatch</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Workspace Stopwatch</name>
+  <summary>An applet to keep track of usage per workspace</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Workspace Timer Applet is an applet to keep track of usage per workspace, e.g. to find out how much minutes/hours were actually spent on a job.
+    </p>
+    <p>
+      Workspaces can be freely named, custom names and all data are remembered, also after logout/restart, until the RESET button is pressed.
+    </p>
+    <p>
+      The log file is updated on workspace switch/clicking the icon for popup or else every 30 seconds.
+    </p>
+    <p>
+      Time during suspend is automatically retracted from a workspace' time.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main applet window</caption>
+      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-workspace-stopwatch/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <icon type="stock">budgie-wstopwatch-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/budgie-workspace-stopwatch/meson.build
+++ b/budgie-workspace-stopwatch/meson.build
@@ -12,3 +12,5 @@ install_data(
     'budgie-wstopwatch-symbolic.svg',
     install_dir: PIXMAPS_DIR
 )
+
+subdir('data')

--- a/budgie-wswitcher/data/meson.build
+++ b/budgie-wswitcher/data/meson.build
@@ -3,3 +3,7 @@ install_data(
     'budgie-wsw-symbolic.svg',
     install_dir: PIXMAPS_DIR
 )
+
+install_data('org.ubuntubudgie.wswitcher.metainfo.xml',
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
+)

--- a/budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml
+++ b/budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
+<component type="addon">
+  <id>org.ubuntubudgie.wswitcher</id>
+  <extends>com.solus-project.budgie-desktop</extends>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Budgie Wallpaper Workspace Switcher</name>
+  <summary>An applet to show a different wallpaper on each of the workspaces</summary>
+  <update_contact>admin@ubuntubudgie.org</update_contact>
+  <description>
+    <p>
+      Budgie Wallpaper Workspace Switcher is an application (applet) to show a different wallpaper on each of the workspaces. Usage is simple: add the applet to the panel and set wallpapers on each of the workspaces in the way you are used to. The applet will remember what wallpaper was set on each of the workspaces.
+    </p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <icon type="stock">budgie-wsw-symbolic</icon>
+  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
+  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
+  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
+  <url type="donation">https://ubuntubudgie.org/donate</url>
+  <project_group>Ubuntu Budgie</project_group>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>


### PR DESCRIPTION
It would be great for these applets to be shown in software centers like
GNOME Software and KDE Discover. Adding these files should accomplish
that.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
