### PR TITLE
Add time of day/night wallpaper support - closes #451

### DIFF
--- a/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml
+++ b/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml
@@ -33,6 +33,30 @@
             <description>In case there are no files in the used folder, a fallback image will be used</description>
             <default>"/usr/share/backgrounds/budgie/ubuntu_budgie_wallpaper1.jpg"</default>
         </key>
-
+        <key type="b" name="timeofday-enabled">
+            <summary>Enable time of day wallpapers</summary>
+            <description>Whether to use separate day and night wallpapers</description>
+            <default>false</default>
+        </key>
+        <key type="s" name="daytime-wallpaper">
+            <summary>Daytime wallpaper</summary>
+            <description>Wallpaper to use during daytime hours</description>
+            <default>""</default>
+        </key>
+        <key type="s" name="nighttime-wallpaper">
+            <summary>Nighttime wallpaper</summary>
+            <description>Wallpaper to use during nighttime hours</description>
+            <default>""</default>
+        </key>
+        <key type="i" name="daytime-start">
+            <summary>Daytime start hour</summary>
+            <description>Hour (0-23) when daytime wallpaper begins</description>
+            <default>7</default>
+        </key>
+        <key type="i" name="nighttime-start">
+            <summary>Nighttime start hour</summary>
+            <description>Hour (0-23) when nighttime wallpaper begins</description>
+            <default>20</default>
+        </key>
     </schema>
 </schemalist>

--- a/budgie-wallstreet/src/wallstreet/wallstreet.vala
+++ b/budgie-wallstreet/src/wallstreet/wallstreet.vala
@@ -24,6 +24,7 @@ namespace WallStreet {
     Settings settings;
     Settings wallpapersettings;
     Settings locksettings;
+    DBusConnection? system_bus;
     int n_images;
     string currwall;
     bool lockscreen_sync;
@@ -34,7 +35,12 @@ namespace WallStreet {
     int curr_seconds;
     int switchinterval;
     bool randomwall;
-
+    bool timeofday_enabled;
+    string daytime_wallpaper;
+    string nighttime_wallpaper;
+    int daytime_start;
+    int nighttime_start;
+    bool last_was_daytime;
 
     public static int main (string[] args) {
 
@@ -60,6 +66,12 @@ namespace WallStreet {
         wallpaperfolder = settings.get_string("wallpaperfolder");
         randomwall = settings.get_boolean("random");
         lockscreen_sync = settings.get_boolean("lockscreensync");
+        timeofday_enabled = settings.get_boolean("timeofday-enabled");
+        daytime_wallpaper = settings.get_string("daytime-wallpaper");
+        nighttime_wallpaper = settings.get_string("nighttime-wallpaper");
+        daytime_start = settings.get_int("daytime-start");
+        nighttime_start = settings.get_int("nighttime-start");
+        last_was_daytime = is_daytime();
 
         // loop start at zero
         curr_seconds = 0;
@@ -74,10 +86,20 @@ namespace WallStreet {
         walldir_monitor = getwallmonitor(wallpaperfolder);
         walldir_monitor.changed.connect(rescan_currdir);
 
-        GLib.Timeout.add_seconds(1, ()=> {
+        // apply time-of-day wallpaper after resume from suspend or on start
+        if (timeofday_enabled) {
+            apply_timeofday();
+            setup_sleep_monitor();
+        }
 
-            // after switchinterval, change wallpaper
-            if (curr_seconds >= switchinterval) {
+        GLib.Timeout.add_seconds(1, ()=> {
+            // check for time-of-day wallpaper transition
+            if (timeofday_enabled) {
+                check_timeofday();
+            }
+
+            // after switchinterval, change wallpaper (skip if timeofday is active)
+            if (!timeofday_enabled && curr_seconds >= switchinterval) {
                 if (randomwall) {
                     int random_int = Random.int_range(0, n_images);
                     currwall = getlist[random_int];
@@ -102,6 +124,25 @@ namespace WallStreet {
 
     private void update_settings (string path) {
         switch (path) {
+            case "timeofday-enabled":
+                timeofday_enabled = settings.get_boolean("timeofday-enabled");
+                if (timeofday_enabled) {
+                    apply_timeofday();
+                    setup_sleep_monitor();
+                }
+                break;
+            case "daytime-wallpaper":
+                daytime_wallpaper = settings.get_string("daytime-wallpaper");
+                break;
+            case "nighttime-wallpaper":
+                nighttime_wallpaper = settings.get_string("nighttime-wallpaper");
+                break;
+            case "daytime-start":
+                daytime_start = settings.get_int("daytime-start");
+                break;
+            case "nighttime-start":
+                nighttime_start = settings.get_int("nighttime-start");
+                break;
             case "wallpaperfolder":
                 wallpaperfolder = settings.get_string("wallpaperfolder");
                 update_wallpaperlist();
@@ -115,6 +156,63 @@ namespace WallStreet {
             case "lockscreensync":
                 lockscreen_sync = settings.get_boolean("lockscreensync");
                 break;
+        }
+    }
+
+    private void apply_timeofday () {
+        bool currently_daytime = is_daytime();
+        last_was_daytime = currently_daytime;
+        string target = currently_daytime ? daytime_wallpaper : nighttime_wallpaper;
+        if (target != "") {
+            set_wallpaper(target);
+            curr_seconds = 0;
+        }
+    }
+
+    private bool is_daytime () {
+        int hour = new DateTime.now_local().get_hour();
+        return hour >= daytime_start && hour < nighttime_start;
+    }
+
+    private void check_timeofday () {
+        bool currently_daytime = is_daytime();
+        if (currently_daytime == last_was_daytime) {
+            return;
+        }
+        apply_timeofday();
+    }
+
+    private void setup_sleep_monitor () {
+        try {
+            if (system_bus != null) {
+                return;
+            }
+            system_bus = Bus.get_sync(BusType.SYSTEM);
+            system_bus.signal_subscribe(
+                "org.freedesktop.login1",
+                "org.freedesktop.login1.Manager",
+                "PrepareForSleep",
+                "/org/freedesktop/login1",
+                null,
+                DBusSignalFlags.NONE,
+                on_prepare_for_sleep
+            );
+        } catch (Error e) {
+            warning("Could not subscribe to sleep signal: %s\n", e.message);
+        }
+    }
+
+    private void on_prepare_for_sleep (DBusConnection conn, string? sender,
+                                       string path, string iface, string signal,
+                                       Variant params) {
+        bool going_to_sleep;
+        params.get("(b)", out going_to_sleep);
+        if (!going_to_sleep && timeofday_enabled) {
+            // waking up — reapply after a short delay to let the desktop settle
+            GLib.Timeout.add(2000, () => {
+                apply_timeofday();
+                return false;
+            });
         }
     }
 
@@ -182,7 +280,7 @@ namespace WallStreet {
             }
         } catch (FileError err) {
             // on error (dir not found), reset wallpaperfolder
-            stderr.printf(err.message);
+            warning(err.message);
             settings.reset("wallpaperfolder");
             images = new GenericArray<string>();
         }

--- a/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala
+++ b/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala
@@ -33,6 +33,15 @@ namespace WallStreetControls {
         ToggleButton toggle_random;
         ToggleButton toggle_synclockscreen;
         ToggleButton toggle_wprunner;
+        CheckButton toggle_timeofday;
+        Entry daytime_entry;
+        Entry nighttime_entry;
+        Button browse_daytime;
+        Button browse_nighttime;
+        SpinButton daytime_start_spin;
+        SpinButton nighttime_start_spin;
+        Grid timeofday_grid;
+        Grid rotation_grid;
         string runinstruction;
 
         public ControlsWindow () {
@@ -54,25 +63,34 @@ namespace WallStreetControls {
                 runinstruction
             );
             maingrid.attach(toggle_wprunner, 1, 1, 100, 1);
-            toggle_random = new Gtk.CheckButton.with_label(
-                (_("Use random wallpaper"))
-            );
-            maingrid.attach(toggle_random, 1, 2, 1, 1);
 
             toggle_synclockscreen = new Gtk.CheckButton.with_label(
                 (_("Sync to lock-screen"))
             );
-            maingrid.attach(toggle_synclockscreen, 1, 3, 1, 1);
+
+            maingrid.attach(toggle_synclockscreen, 1, 2, 1, 1);
+
+            // rotation-specific widgets in their own grid
+            rotation_grid = new Gtk.Grid();
+            rotation_grid.set_row_spacing(6);
+            maingrid.attach(rotation_grid, 1, 3, 99, 1);
+
+            var rotation_separator = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
+            rotation_grid.attach(rotation_separator, 0, 0, 99, 1);
+
+            toggle_random = new Gtk.CheckButton.with_label(
+                (_("Use random wallpaper"))
+            );
+            rotation_grid.attach(toggle_random, 0, 1, 1, 1);
+
             var toggle_defaultwalls = new Gtk.CheckButton.with_label(
                 (_("Use default wallpapers"))
             );
-            maingrid.attach(toggle_defaultwalls, 1, 4, 1, 1);
-            // spacer
-            var givemesomespace = new Gtk.Label("");
-            maingrid.attach(givemesomespace, 1, 10, 1, 1);
+            rotation_grid.attach(toggle_defaultwalls, 0, 2, 1, 1);
+
             // custom folder section
             Box box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            maingrid.attach(box, 1, 11, 99, 1);
+            rotation_grid.attach(box, 0, 3, 99, 1);
             set_customtwalls = new Gtk.Button.with_label(
                 (_("Browse"))
             );
@@ -83,15 +101,13 @@ namespace WallStreetControls {
             dir_entry.set_editable(false);
             box.pack_start(dir_entry, false, false, 0);
             box.pack_start(new Label("\t"), false, false, 0);
-            // spacer
-            var empty = new Label("");
-            maingrid.attach(empty, 1, 12, 1, 1);
+
             // time settings section
             var time_label = new Label("\n" + (_("Change interval")) + "\n");
             time_label.set_xalign(0);
-            maingrid.attach(time_label, 1, 13, 1, 1);
+            rotation_grid.attach(time_label, 0, 4, 1, 1);
             var timegrid = new Gtk.Grid();
-            maingrid.attach(timegrid, 1, 14, 2, 3);
+            rotation_grid.attach(timegrid, 0, 5, 2, 3);
             var hours_label = new Label((_("Hours")) + "\t");
             hours_label.set_xalign(0);
             timegrid.attach(hours_label, 0, 0, 1, 1);
@@ -107,6 +123,83 @@ namespace WallStreetControls {
             timegrid.attach(seconds_label, 0, 2, 1, 1);
             seconds_spin = new Gtk.SpinButton.with_range(0, 59, 1);
             timegrid.attach(seconds_spin, 1, 2, 1, 1);
+
+            // time of day section
+            var timeofday_separator = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
+            maingrid.attach(timeofday_separator, 1, 4, 99, 1);
+
+            toggle_timeofday = new Gtk.CheckButton.with_label(
+                (_("Use time of day wallpapers"))
+            );
+            maingrid.attach(toggle_timeofday, 1, 5, 99, 1);
+
+            timeofday_grid = new Gtk.Grid();
+            timeofday_grid.set_row_spacing(6);
+            timeofday_grid.set_column_spacing(10);
+            maingrid.attach(timeofday_grid, 1, 6, 99, 1);
+
+            var daytime_start_label = new Label((_("Daytime starts at hour")) + "\t");
+            daytime_start_label.set_xalign(0);
+            timeofday_grid.attach(daytime_start_label, 0, 0, 1, 1);
+            daytime_start_spin = new Gtk.SpinButton.with_range(0, 23, 1);
+            timeofday_grid.attach(daytime_start_spin, 1, 0, 1, 1);
+
+            var nighttime_start_label = new Label((_("Nighttime starts at hour")) + "\t");
+            nighttime_start_label.set_xalign(0);
+            timeofday_grid.attach(nighttime_start_label, 0, 1, 1, 1);
+            nighttime_start_spin = new Gtk.SpinButton.with_range(0, 23, 1);
+            timeofday_grid.attach(nighttime_start_spin, 1, 1, 1, 1);
+
+            var daytime_label = new Label((_("Daytime wallpaper")) + "\t");
+            daytime_label.set_xalign(0);
+            timeofday_grid.attach(daytime_label, 0, 2, 1, 1);
+            Box daytime_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+            timeofday_grid.attach(daytime_box, 1, 2, 1, 1);
+            browse_daytime = new Gtk.Button.with_label((_("Browse")));
+            daytime_box.pack_start(browse_daytime, false, false, 0);
+            daytime_entry = new Gtk.Entry();
+            daytime_entry.set_width_chars(35);
+            daytime_entry.set_editable(false);
+            daytime_box.pack_start(daytime_entry, false, false, 10);
+
+            var nighttime_label = new Label((_("Nighttime wallpaper")) + "\t");
+            nighttime_label.set_xalign(0);
+            timeofday_grid.attach(nighttime_label, 0, 3, 1, 1);
+            Box nighttime_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+            timeofday_grid.attach(nighttime_box, 1, 3, 1, 1);
+            browse_nighttime = new Gtk.Button.with_label((_("Browse")));
+            nighttime_box.pack_start(browse_nighttime, false, false, 0);
+            nighttime_entry = new Gtk.Entry();
+            nighttime_entry.set_width_chars(35);
+            nighttime_entry.set_editable(false);
+            nighttime_box.pack_start(nighttime_entry, false, false, 10);
+
+            // fetch initial values
+            bool timeofday_active = wallstreet_settings.get_boolean("timeofday-enabled");
+            toggle_timeofday.set_active(timeofday_active);
+            daytime_start_spin.set_value(wallstreet_settings.get_int("daytime-start"));
+            nighttime_start_spin.set_value(wallstreet_settings.get_int("nighttime-start"));
+            string dwall = wallstreet_settings.get_string("daytime-wallpaper");
+            if (dwall != "") daytime_entry.set_text(dwall);
+            string nwall = wallstreet_settings.get_string("nighttime-wallpaper");
+            if (nwall != "") nighttime_entry.set_text(nwall);
+            toggle_timeofday_widgets(timeofday_active);
+
+            // connect signals
+            toggle_timeofday.toggled.connect(manage_boolean);
+            browse_daytime.clicked.connect(get_daytime_wallpaper);
+            browse_nighttime.clicked.connect(get_nighttime_wallpaper);
+            daytime_start_spin.value_changed.connect(() => {
+                wallstreet_settings.set_int(
+                    "daytime-start", (int)daytime_start_spin.get_value()
+                );
+            });
+            nighttime_start_spin.value_changed.connect(() => {
+                wallstreet_settings.set_int(
+                    "nighttime-start", (int)nighttime_start_spin.get_value()
+                );
+            });
+
             var ok_button = new Button.with_label((_("Close")));
             maingrid.attach(ok_button, 99, 99, 1, 1);
             ok_button.clicked.connect(Gtk.main_quit);
@@ -173,6 +266,11 @@ namespace WallStreetControls {
                     "lockscreensync", button.get_active()
                 );
             }
+            else if (button == toggle_timeofday) {
+                bool active = button.get_active();
+                wallstreet_settings.set_boolean("timeofday-enabled", active);
+                toggle_timeofday_widgets(active);
+            }
             else if (button == toggle_wprunner) {
                 bool newsetting = button.get_active();
                 wallstreet_settings.set_boolean(
@@ -185,6 +283,11 @@ namespace WallStreetControls {
                     toggle_wprunner.set_label(runinstruction);
                 }
             }
+        }
+
+        private void toggle_timeofday_widgets (bool active) {
+            timeofday_grid.set_sensitive(active);
+            rotation_grid.set_sensitive(!active);
         }
 
         private void check_firstrunwarning() {
@@ -227,6 +330,43 @@ namespace WallStreetControls {
                 return false;
             }
             return false;
+        }
+
+        private void get_daytime_wallpaper (Button button) {
+            string? path = pick_image_file();
+            if (path != null) {
+                wallstreet_settings.set_string("daytime-wallpaper", path);
+               daytime_entry.set_text(path);
+            }
+        }
+
+        private void get_nighttime_wallpaper (Button button) {
+            string? path = pick_image_file();
+            if (path != null) {
+                wallstreet_settings.set_string("nighttime-wallpaper", path);
+                nighttime_entry.set_text(path);
+            }
+        }
+
+        private string? pick_image_file () {
+            string? result = null;
+            var chooser = new Gtk.FileChooserDialog(
+                (_("Select a wallpaper")),
+                null, Gtk.FileChooserAction.OPEN,
+                (_("Cancel")), Gtk.ResponseType.CANCEL,
+                (_("Use")), Gtk.ResponseType.ACCEPT
+            );
+            var filter = new Gtk.FileFilter();
+            filter.set_filter_name((_("Images")));
+            filter.add_mime_type("image/jpeg");
+            filter.add_mime_type("image/png");
+            filter.add_mime_type("image/svg+xml");
+            chooser.add_filter(filter);
+            if (chooser.run() == Gtk.ResponseType.ACCEPT) {
+                result = chooser.get_file().get_path();
+            }
+            chooser.close();
+            return result;
         }
 
         private void manage_direntry (ToggleButton button) {


### PR DESCRIPTION
add gsettings, daemon and gui support to add an option to change a wallpaper  depending on the user selection of a day or night hour.

Copes with suspend/resume actions as well to update the wallpaper if required.